### PR TITLE
Standardize guava to version 23.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>19.0</version>
+                <version>23.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.google.inject</groupId>

--- a/yqlplus_language/pom.xml
+++ b/yqlplus_language/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>23.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>

--- a/yqlplus_source_api/pom.xml
+++ b/yqlplus_source_api/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>19.0</version>
+            <version>23.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/yqlplus_source_api/src/main/java/com/yahoo/yqlplus/api/types/Annotations.java
+++ b/yqlplus_source_api/src/main/java/com/yahoo/yqlplus/api/types/Annotations.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hasher;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -59,7 +60,7 @@ public class Annotations implements Iterable<Map.Entry<String, Object>> {
 
         @Override
         public Iterator<Map.Entry<String, Object>> iterator() {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
         }
     };
 


### PR DESCRIPTION
Annotations.java updated to use Collections.emptyIterator() as Guava
abandoned its equivalent functionality