### PR TITLE
Maven Pom Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,13 @@
 
     <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_engine_project</artifactId>
-    <version>1.0.3</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>yqlplus_engine_project</name>
     <description>yqlplus_engine_project</description>
     <properties>
+        <yqlplus.version>2.0.0-SNAPSHOT</yqlplus.version>
         <additionalparam>-Xdoclint:none</additionalparam>
         <min_jdk_version>1.8</min_jdk_version>
     </properties>
@@ -41,11 +43,6 @@
                 </exclusions>
             </dependency>
             <dependency>
-              <groupId>org.antlr</groupId>
-              <artifactId>antlr4-runtime</artifactId>
-              <version>4.5</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>23.1-jre</version>
@@ -68,22 +65,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.1.1</version>
+                <version>2.2.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-cli</groupId>
                 <artifactId>commons-cli</artifactId>
                 <version>1.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mozilla</groupId>
-                <artifactId>rhino</artifactId>
-                <version>1.7R4</version>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>
@@ -94,6 +86,11 @@
                 <groupId>com.yahoo.rdl</groupId>
                 <artifactId>rdl-java</artifactId>
                 <version>1.4.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>2.0.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/yqlplus_engine/pom.xml
+++ b/yqlplus_engine/pom.xml
@@ -12,23 +12,22 @@
     <parent>
         <groupId>com.yahoo.yqlplus</groupId>
         <artifactId>yqlplus_engine_project</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_engine</artifactId>
-    <version>1.0.3</version>
+
     <dependencies>
         <dependency>
             <groupId>com.yahoo.yqlplus</groupId>
             <artifactId>yqlplus_language</artifactId>
-            <version>1.0.3</version>
+            <version>${yqlplus.version}</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.yqlplus</groupId>
             <artifactId>yqlplus_source_api</artifactId>
-            <version>1.0.3</version>
+            <version>${yqlplus.version}</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.monitor</groupId>
@@ -55,38 +54,31 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
-            <version>4.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>
@@ -106,7 +98,6 @@
         <dependency>
             <groupId>com.yahoo.rdl</groupId>
             <artifactId>rdl-java</artifactId>
-            <version>1.4.8</version>
         </dependency>
     </dependencies>
 
@@ -127,7 +118,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.5</version>
+                <version>4.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/yqlplus_javadocs/pom.xml
+++ b/yqlplus_javadocs/pom.xml
@@ -12,14 +12,13 @@
     <parent>
         <groupId>com.yahoo.yqlplus</groupId>
         <artifactId>yqlplus_engine_project</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_javadocs</artifactId>
-    <version>1.0.3</version>
     <build>
         <finalName>yqlplus_javadocs</finalName>
     </build>
+
 </project>

--- a/yqlplus_language/pom.xml
+++ b/yqlplus_language/pom.xml
@@ -13,17 +13,11 @@
     <parent>
         <groupId>com.yahoo.yqlplus</groupId>
         <artifactId>yqlplus_engine_project</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_language</artifactId>
-    <packaging>jar</packaging>
-    <version>1.0.3</version>
-    <properties>
-        <min_jdk_version>1.8</min_jdk_version>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -41,34 +35,34 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.5</version>
+            <version>4.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-annotations</artifactId>
+            <version>4.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <version>2.0.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.1.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.1.1</version>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -78,7 +72,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.5</version>
+                <version>4.7</version>
                 <executions>
                     <execution>
                         <configuration>

--- a/yqlplus_source_api/pom.xml
+++ b/yqlplus_source_api/pom.xml
@@ -14,25 +14,21 @@
     <parent>
         <groupId>com.yahoo.yqlplus</groupId>
         <artifactId>yqlplus_engine_project</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_source_api</artifactId>
-    <version>1.0.3</version>
     
     <dependencies>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
-            <version>4.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.1-jre</version>
         </dependency>
     </dependencies>
 

--- a/yqlplus_stdlib/pom.xml
+++ b/yqlplus_stdlib/pom.xml
@@ -12,35 +12,32 @@
     <parent>
         <groupId>com.yahoo.yqlplus</groupId>
         <artifactId>yqlplus_engine_project</artifactId>
-        <version>1.0.3</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <groupId>com.yahoo.yqlplus</groupId>
     <artifactId>yqlplus_stdlib</artifactId>
-    <version>1.0.3</version>
+    <version>${yqlplus.version}</version>
     <dependencies>
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-multibindings</artifactId>
             <optional>true</optional>
-            <version>4.0</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.yqlplus</groupId>
             <artifactId>yqlplus_source_api</artifactId>
-            <version>1.0.3</version>
+            <version>${yqlplus.version}</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.yqlplus</groupId>
             <artifactId>yqlplus_engine</artifactId>
-            <version>1.0.3</version>
+            <version>${yqlplus.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.threeten</groupId>
             <artifactId>threetenbp</artifactId>
-            <version>0.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
  * Parent pom
    * version updated to 2.0.0-SNAPSHOT
    * Expose yqlplus.version property for standardizing dependency
    * remove antlr from parent - only 1 submodule uses it
    * Update jackson dep to child module max version
    * Remove rhino dep.  Not used
    * Added findbugs dep, uses in 2 child modules.
  * javadocs pom
    * Rely on parent pom for version and groupId
  * language pom
    * Rely on parent pom for version and groupId
    * Remove min_jdk_version property, rely on parent
    * Remove packaging element - redundant declaration
    * Update to antlr 4.7
    * Rely on parent pom for guava, jsr305, guice, jackson dependencies
  * source api pom
    * Rely on parent pom for version and groupId
    * Rely on parent pom for guava, guice dependencies
  * stdlib pom
    * Rely on parent pom for version and groupId
    * Rely on parent pom for guice, yqlplus, threetenbp dependencies
  * engine pom
    * Rely on parent pom for version and groupId
    * Rely on parent pom for guice, yqlplus, jsr305, jackson, commons-cli, threetenbp dependencies
    * Update for antlr 4.7