### PR TITLE
Fix generation of MERGE statements where when later statements depend…

### DIFF
--- a/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/ast/PhysicalOperator.java
+++ b/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/ast/PhysicalOperator.java
@@ -23,6 +23,8 @@ public enum PhysicalOperator implements Operator {
 
     // context
     EVALUATE(PhysicalExprOperator.class, PhysicalExprOperator.class),
+    // execute evalutes and expression and throws away the result
+    EXECUTE(PhysicalExprOperator.class, PhysicalExprOperator.class),
     // evaluate_guard enforces the timeout on the computation
     EVALUATE_GUARD(PhysicalExprOperator.class, PhysicalExprOperator.class);
 
@@ -61,6 +63,8 @@ public enum PhysicalOperator implements Operator {
                 OperatorNode<PhysicalExprOperator> expr = op.getArgument(1);
                 return true;
             }
+            case EXECUTE:
+                return false;
             default:
                 throw new IllegalArgumentException("unknown PhysicalOperator: " + op);
         }
@@ -73,6 +77,7 @@ public enum PhysicalOperator implements Operator {
             case REQUIRED_ARGUMENT:
             case OPTIONAL_ARGUMENT:
                 return false;
+            case EXECUTE:
             case EVALUATE: {
                 OperatorNode<PhysicalExprOperator> expr = op.getArgument(1);
                 return expr.getOperator().asyncFor(expr);

--- a/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/streams/MergeStreamValue.java
+++ b/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/streams/MergeStreamValue.java
@@ -72,7 +72,7 @@ public class MergeStreamValue extends StreamValue {
         OperatorNode<PhysicalExprOperator> complete = OperatorNode.create(PhysicalExprOperator.STREAM_COMPLETE, stream, steps);
 
         return ImmutableList.of(
-                OperatorStep.create(context.getValueTypeAdapter(), PhysicalOperator.EVALUATE, OperatorNode.create(PhysicalExprOperator.STREAM_EXECUTE, complete,
+                OperatorStep.create(context.getValueTypeAdapter(), PhysicalOperator.EXECUTE, OperatorNode.create(PhysicalExprOperator.STREAM_EXECUTE, complete,
                         setSink(this.stream, OperatorNode.create(SinkOperator.STREAM,
                                 OperatorNode.create(PhysicalExprOperator.VALUE, stream))))));
     }

--- a/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/streams/SourceStreamValue.java
+++ b/yqlplus_engine/src/main/java/com/yahoo/yqlplus/engine/internal/plan/streams/SourceStreamValue.java
@@ -46,7 +46,7 @@ public class SourceStreamValue extends StreamValue {
     @Override
     public Collection<OperatorValue> feed(OperatorValue stream) {
         OperatorNode<SinkOperator> sink = OperatorNode.create(SinkOperator.STREAM, OperatorNode.create(PhysicalExprOperator.VALUE, stream));
-        return ImmutableList.of(OperatorStep.create(context.getValueTypeAdapter(), source.getLocation(), PhysicalOperator.EVALUATE, context.getContextExpr(),
+        return ImmutableList.of(OperatorStep.create(context.getValueTypeAdapter(), source.getLocation(), PhysicalOperator.EXECUTE, context.getContextExpr(),
                 OperatorNode.create(PhysicalExprOperator.STREAM_EXECUTE, source, setSink(this.stream, sink))));
     }
 }

--- a/yqlplus_engine/src/test/java/com/yahoo/yqlplus/engine/java/EvaluateStatementTest.java
+++ b/yqlplus_engine/src/test/java/com/yahoo/yqlplus/engine/java/EvaluateStatementTest.java
@@ -2,12 +2,18 @@ package com.yahoo.yqlplus.engine.java;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Provider;
 import com.google.inject.util.Providers;
 import com.yahoo.yqlplus.api.Exports;
+import com.yahoo.yqlplus.api.Source;
 import com.yahoo.yqlplus.api.annotations.Export;
+import com.yahoo.yqlplus.api.annotations.Query;
+import com.yahoo.yqlplus.engine.CompiledProgram;
+import com.yahoo.yqlplus.engine.api.Record;
 import com.yahoo.yqlplus.engine.internal.bytecode.CompilingTestBase;
 import com.yahoo.yqlplus.engine.internal.plan.ContextPlanner;
 import com.yahoo.yqlplus.engine.internal.plan.ModuleType;
@@ -17,6 +23,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class EvaluateStatementTest extends CompilingTestBase {
@@ -28,6 +35,11 @@ public class EvaluateStatementTest extends CompilingTestBase {
         }
 
         @Export
+        public List<String> names_by_key(List<String> keys) {
+            return keys;
+        }
+
+        @Export
         public ListenableFuture<List<String>> namesAsync() {
             return Futures.immediateFuture(names());
         }
@@ -35,6 +47,51 @@ public class EvaluateStatementTest extends CompilingTestBase {
         @Export
         public CompletableFuture<List<String>> namesJavaAsync() {
             return CompletableFuture.completedFuture(names());
+        }
+    }
+
+    public static class TestRecord implements Record {
+        private Map<String,Object> data;
+
+        public TestRecord(Map<String, Object> data) {
+            this.data = data;
+        }
+
+
+        public TestRecord(String id) {
+            this(ImmutableMap.of("id", id));
+        }
+
+        @Override
+        public Iterable<String> getFieldNames() {
+            return data.keySet();
+        }
+
+        @Override
+        public Object get(String field) {
+            return data.get(field);
+        }
+    }
+
+    public static class TestSource implements Source {
+        @Query
+        public List<TestRecord> scan() {
+            return ImmutableList.of();
+        }
+
+        @Query
+        public List<TestRecord> oneArg(Object any) {
+            return ImmutableList.of();
+        }
+
+        @Query
+        public List<TestRecord> twoArg(Object any, Object any2) {
+            return ImmutableList.of();
+        }
+
+        @Query
+        public List<TestRecord> threeArg(Object any, Object any2, Object three) {
+            return ImmutableList.of();
         }
     }
 
@@ -66,5 +123,15 @@ public class EvaluateStatementTest extends CompilingTestBase {
     public void requireEvaluateCallASyncJava() throws Exception {
         List<String> result = runQueryProgram("EVALUATE test.namesJavaAsync()");
         Assert.assertEquals(result, ImmutableList.of("a", "b", "c"));
+    }
+
+    @Test
+    public void requireComplexPlanningExample() throws Exception {
+        defineSource("table4", TestSource.class);
+        defineSource("table5", TestSource.class);
+        defineSource("table10", TestSource.class);
+        CompiledProgram program = compileProgramResource("dashboard.yql");
+        List<String> output = Lists.newArrayList(program.run(ImmutableMap.of(), true).getResultNames());
+        Assert.assertEquals(output.size(), 8);
     }
 }

--- a/yqlplus_engine/src/test/resources/com/yahoo/yqlplus/engine/java/dashboard.yql
+++ b/yqlplus_engine/src/test/resources/com/yahoo/yqlplus/engine/java/dashboard.yql
@@ -1,0 +1,74 @@
+PROGRAM (@arg1 array<string> = [],
+         @arg2 array<int32> = [],
+         @arg3 string = '1',
+         @arg4 boolean = false);
+
+CREATE TEMP TABLE table1 as (
+    SELECT *
+    FROM table5 (@arg2)
+);
+
+CREATE TEMP TABLE table2 as (
+    SELECT value
+    FROM table1
+);
+
+CREATE TEMP TABLE table3 AS(
+SELECT *
+FROM table4(@table2)
+);
+
+SELECT league_key from table1
+OUTPUT as my_league_keys;
+
+SELECT *
+FROM table1
+OUTPUT as my_leagues_and_team_keys;
+
+SELECT * FROM table3
+OUTPUT AS matchups_by_league_key;
+
+CREATE TEMP TABLE tmptable1 AS (
+SELECT * FROM table5(@table3));
+
+CREATE TEMP TABLE tmptable5 as (
+    SELECT value FROM table2
+);
+
+SELECT * FROM tmptable1 OUTPUT as test;
+
+CREATE TEMP TABLE tmptable2 AS (
+SELECT value AS team_key FROM tmptable5
+MERGE
+SELECT team1_key AS team_key FROM tmptable1
+MERGE
+SELECT team2_key AS team_key FROM tmptable1
+);
+
+CREATE TEMP TABLE teams_tmp AS (
+SELECT *
+FROM table5
+WHERE team_key IN (SELECT team_key FROM tmptable2));
+
+CREATE TEMP TABLE matchup_slots_tmp AS
+(EVALUATE test.names_by_key(@table3));
+
+SELECT team_key, team_name, links, images
+FROM teams_tmp
+OUTPUT AS teams;
+
+// build team recaps
+SELECT team_key, recaps
+FROM table5(@teams_tmp, @table3)
+WHERE team_key IN (SELECT value AS team_key FROM tmptable5)
+OUTPUT AS team_recaps;
+
+SELECT team_key, type, text, tokenized_text, player_keys, links, deep_links
+FROM table5()
+WHERE team_key IN (SELECT value FROM tmptable5)
+OUTPUT AS alerts_by_team_keys;
+
+SELECT *
+    FROM table5({"arg1": @arg1})
+    WHERE team_key IN (SELECT team_key FROM tmptable2)
+OUTPUT AS records;


### PR DESCRIPTION
… on the output of the MERGE the resulting program ran into a planner bug because the EVALUATE used to feed merged results was type VOID but the planner believed it resulted in an output value.